### PR TITLE
fix: workflow, not deployment, notifications

### DIFF
--- a/src/modules/deploy_notifications/index.ts
+++ b/src/modules/deploy_notifications/index.ts
@@ -1,14 +1,14 @@
 import {Probot} from "probot";
 import {
-  deployCancelledTemplate,
-  deployFailedTemplate,
-  deploySucceedTemplate, deployTimedOutTemplate, getEnvChannelName,
+  workflowCancelledTemplate,
+  workflowFailedTemplate,
+  workflowSucceedTemplate, workflowTimedOutTemplate, getEnvChannelName,
   MessageContent, sendDeployNotification
 } from "../../notification_helpers";
 import Queue from "async-await-queue";
 import {logger} from "../../shared/logger";
 
-export const deploy_notifications_listener = (app: Probot) => {
+export const workflow_notifications_listener = (app: Probot) => {
   const CONSOLE_DEPLOY_WORKFLOW_ID = parseInt(process.env.CONSOLE_DEPLOY_WORKFLOW_ID || '');
   const NEON_DEPLOY_WORKFLOW_ID = parseInt(process.env.NEON_DEPLOY_WORKFLOW_ID || '');
 
@@ -36,21 +36,21 @@ export const deploy_notifications_listener = (app: Probot) => {
 
           let msg: MessageContent | undefined;
           switch (workflow_run.workflow_id) {
-            // deploy to staging
+            // workflow to staging
             case CONSOLE_DEPLOY_WORKFLOW_ID:
             case NEON_DEPLOY_WORKFLOW_ID:
               switch (workflow_run.conclusion) {
                 case "success":
-                  msg = deploySucceedTemplate(workflow_run);
+                  msg = workflowSucceedTemplate(workflow_run);
                   break;
                 case "failure":
-                  msg = deployFailedTemplate(workflow_run);
+                  msg = workflowFailedTemplate(workflow_run);
                   break;
                 case "cancelled":
-                  msg = deployCancelledTemplate(workflow_run);
+                  msg = workflowCancelledTemplate(workflow_run);
                   break;
                 case "timed_out":
-                  msg = deployTimedOutTemplate(workflow_run);
+                  msg = workflowTimedOutTemplate(workflow_run);
                   break;
               }
               break;

--- a/src/notification_helpers.ts
+++ b/src/notification_helpers.ts
@@ -89,7 +89,7 @@ const getCommitEmbeds: (w: any) => Block|KnownBlock = (
   };
 }
 
-export const getDeploymentEnv = (workflow_run: any) => {
+const getWorkflowEnv = (workflow_run: any) => {
   if (isConsoleRepo(workflow_run)) {
     if (workflow_run.head_branch == process.env.CONSOLE_STAGING_BRANCH_NAME) {
       return "*[ STAGING CONSOLE ]*";
@@ -105,16 +105,16 @@ export const getDeploymentEnv = (workflow_run: any) => {
       return "*[ PRODUCTION NEON ]*";
     }
   }
-  throw new Error("Unknown deployment workflow run id");
+  throw new Error("Unknown workflow run id");
 }
 
-export const deploySucceedTemplate: TemplateFunc = (workflow_run: any) => {
+export const workflowSucceedTemplate: TemplateFunc = (workflow_run: any) => {
   let component = 'console';
   if (isNeonRepo(workflow_run)) {
     component = 'storage'
   }
 
-  const header = `New ${component} version has been successfully deployed.`
+  const header = `New ${component} commit has been successfully merged.`
 
   return {
     text: header,
@@ -123,7 +123,7 @@ export const deploySucceedTemplate: TemplateFunc = (workflow_run: any) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `${ResultIcons.Success}  ${getDeploymentEnv(workflow_run)} ${header}\n` +
+          text: `${ResultIcons.Success}  ${getWorkflowEnv(workflow_run)} ${header}\n` +
             `Deploy number: ${workflow_run.run_number}.\n` +
             `HEAD now is: \n`,
         }
@@ -133,8 +133,8 @@ export const deploySucceedTemplate: TemplateFunc = (workflow_run: any) => {
   };
 }
 
-export const deployFailedTemplate: TemplateFunc = (workflow_run: any) => {
-  const header = `Deployment #${workflow_run.run_number} failed`
+export const workflowFailedTemplate: TemplateFunc = (workflow_run: any) => {
+  const header = `Workflow #${workflow_run.run_number} failed`
 
   return {
     text: header,
@@ -143,7 +143,7 @@ export const deployFailedTemplate: TemplateFunc = (workflow_run: any) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `${ResultIcons.Failed}  ${getDeploymentEnv(workflow_run)} ${header} :(\n` +
+          text: `${ResultIcons.Failed}  ${getWorkflowEnv(workflow_run)} ${header} :(\n` +
             `Logs: <${workflow_run.html_url}|view on github>\n` +
             `Commit details:`,
         }
@@ -153,8 +153,8 @@ export const deployFailedTemplate: TemplateFunc = (workflow_run: any) => {
   };
 }
 
-export const deployTimedOutTemplate: TemplateFunc = (workflow_run: any) => {
-  const header = `Deployment #${workflow_run.run_number} timed out.`;
+export const workflowTimedOutTemplate: TemplateFunc = (workflow_run: any) => {
+  const header = `Workflow #${workflow_run.run_number} timed out.`;
   return {
     text: header,
     blocks: [
@@ -162,7 +162,7 @@ export const deployTimedOutTemplate: TemplateFunc = (workflow_run: any) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `${ResultIcons.TimedOut}  ${getDeploymentEnv(workflow_run)} ${header}`,
+          text: `${ResultIcons.TimedOut}  ${getWorkflowEnv(workflow_run)} ${header}`,
         }
       },
       getCommitEmbeds(workflow_run),
@@ -170,8 +170,8 @@ export const deployTimedOutTemplate: TemplateFunc = (workflow_run: any) => {
   };
 }
 
-export const deployCancelledTemplate: TemplateFunc = (workflow_run: any) => {
-  const header = `Deployment #${workflow_run.run_number} was cancelled.`;
+export const workflowCancelledTemplate: TemplateFunc = (workflow_run: any) => {
+  const header = `Workflow #${workflow_run.run_number} was cancelled.`;
 
   return {
     text: header,
@@ -180,7 +180,7 @@ export const deployCancelledTemplate: TemplateFunc = (workflow_run: any) => {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `${ResultIcons.Cancelled}  ${getDeploymentEnv(workflow_run)} ${header}`,
+          text: `${ResultIcons.Cancelled}  ${getWorkflowEnv(workflow_run)} ${header}`,
         }
       },
       getCommitEmbeds(workflow_run),

--- a/src/webhooks.ts
+++ b/src/webhooks.ts
@@ -7,7 +7,7 @@ export = (app: Probot) => {
   l.sync_roadmap_ship_target_with_subtasks_listener(app);
   l.engineering_projects_manager_listener(app);
   l.pull_request_label_change_listener(app);
-  l.deploy_notifications_listener(app);
+  l.workflow_notifications_listener(app);
 
   //
   // we can also:


### PR DESCRIPTION
change the slack notifications from "deployment" to "workflow" or "merge" (even though that is kind of wrong as well). this follows changes made months ago to only kick off a remote deployment job from the repository `main` or `release` workflow runs, so it is confusing to see in slack "deployment failed" even though we are deploying or have already deployed the commit.