### PR TITLE
Enable sync roadmap field with children

### DIFF
--- a/src/modules/sync_fields_cross_projects/config.ts
+++ b/src/modules/sync_fields_cross_projects/config.ts
@@ -1,4 +1,4 @@
-import {DBAAS, PRODUCT_DESIGN} from "../../shared/project_ids";
+import {PRODUCT_DELIVERY, PRODUCT_DESIGN} from "../../shared/project_ids";
 
 // {sourceFieldId: []}
 export type TargetFields = Record<string, Array<{
@@ -13,13 +13,23 @@ export type SyncFieldsConfig = {
 };
 
 // {sourceProjectId: []}
+// @ts-ignore
 export const CONFIG: Record<string, SyncFieldsConfig> = {
   [PRODUCT_DESIGN.projectId]: {
     forceSyncFieldId: PRODUCT_DESIGN.forceSyncFieldId,
     to: {
-      [PRODUCT_DESIGN.statusFieldId]: [
-        {projectId: DBAAS.projectId, fieldId: DBAAS.designStatusFieldId}
-      ]
+      [PRODUCT_DESIGN.statusFieldId]: PRODUCT_DELIVERY
+        .filter(({designStatusFieldId}) => !!designStatusFieldId)
+        .map(({projectId, designStatusFieldId}) => ({
+          projectId,
+          designStatusFieldId,
+        })),
+      [PRODUCT_DESIGN.figmaLinkFieldId]: PRODUCT_DELIVERY
+        .filter(({figmaLinkFieldId}) => !!figmaLinkFieldId)
+        .map(({projectId, figmaLinkFieldId}) => ({
+          projectId,
+          figmaLinkFieldId,
+        }))
     }
   },
 }

--- a/src/modules/sync_roadmap_ship_target_with_subtasks/sync_roadmap_changes_with_eng_projects.ts
+++ b/src/modules/sync_roadmap_ship_target_with_subtasks/sync_roadmap_changes_with_eng_projects.ts
@@ -2,13 +2,8 @@ import {Context} from "probot/lib/context";
 import {EmitterWebhookEvent, EmitterWebhookEventName, } from "@octokit/webhooks";
 
 import {
-  ALL_EPICS,
-  AUTOSCALING, COMPUTE,
-  CONSOLE, CONTROL_PLANE, DATA, DOCS,
-  ENGINEERING,
-  INFRA,
-  NEON_PRIVATE_ROADMAP, PIXEL_POINT, POSTGRES, PRODUCT,
-  PRODUCT_DESIGN
+  ALL_TEAMS_PROJECTS,
+  NEON_PRIVATE_ROADMAP,
 } from "../../shared/project_ids";
 import {Issue} from "../../shared/issue";
 import {Octokit} from "@octokit/core";
@@ -18,148 +13,57 @@ import {logger} from "../../shared/logger";
 
 const FIELDS_MAPPING = [
   {
-    from: NEON_PRIVATE_ROADMAP.targetShipMothFieldId,
-    to: [
-      {
-        projectId: CONSOLE.projectId,
-        fieldId: CONSOLE.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: ENGINEERING.projectId,
-        fieldId: ENGINEERING.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: PRODUCT_DESIGN.projectId,
-        fieldId: PRODUCT_DESIGN.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: INFRA.projectId,
-        fieldId: INFRA.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: AUTOSCALING.projectId,
-        fieldId: AUTOSCALING.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: CONTROL_PLANE.projectId,
-        fieldId: CONTROL_PLANE.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: DATA.projectId,
-        fieldId: DATA.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: COMPUTE.projectId,
-        fieldId: COMPUTE.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: DOCS.projectId,
-        fieldId: DOCS.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: POSTGRES.projectId,
-        fieldId: POSTGRES.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: PRODUCT.projectId,
-        fieldId: PRODUCT.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: PIXEL_POINT.projectId,
-        fieldId: PIXEL_POINT.roadmapTargetShipMonthFieldId,
-      },
-      {
-        projectId: ALL_EPICS.projectId,
-        fieldId: ALL_EPICS.roadmapTargetShipMonthFieldId,
-      },
-    ]
-  },
-  {
     from: NEON_PRIVATE_ROADMAP.targetShipQuarterFieldId,
-    to: [
-      {
-        projectId: CONSOLE.projectId,
-        fieldId: CONSOLE.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: ENGINEERING.projectId,
-        fieldId: ENGINEERING.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: PRODUCT_DESIGN.projectId,
-        fieldId: PRODUCT_DESIGN.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: AUTOSCALING.projectId,
-        fieldId: AUTOSCALING.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: CONTROL_PLANE.projectId,
-        fieldId: CONTROL_PLANE.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: DATA.projectId,
-        fieldId: DATA.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: COMPUTE.projectId,
-        fieldId: COMPUTE.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: DOCS.projectId,
-        fieldId: DOCS.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: POSTGRES.projectId,
-        fieldId: POSTGRES.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: PRODUCT.projectId,
-        fieldId: PRODUCT.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: PIXEL_POINT.projectId,
-        fieldId: PIXEL_POINT.roadmapTargetShipQuarterFieldId,
-      },
-      {
-        projectId: ALL_EPICS.projectId,
-        fieldId: ALL_EPICS.roadmapTargetShipQuarterFieldId,
-      },
-    ]
+    to: ALL_TEAMS_PROJECTS
+      .filter(({roadmapTargetShipQuarterFieldId}) => !!roadmapTargetShipQuarterFieldId)
+      .map(({projectId, roadmapTargetShipQuarterFieldId}) => ({
+        projectId,
+        fieldId: roadmapTargetShipQuarterFieldId,
+      }))
   }
 ];
 
 const syncFieldValuesWithSubtasks = async (kit: Octokit, roadmapNodeId: string, issues: Issue[], fieldMapping: Array<{ from: string | undefined, to: Array<{ projectId: string, fieldId: string | undefined }> }>) => {
-  const {node} = await kit.graphql(projectV2ItemByNodeId, {project_item_id: roadmapNodeId});
-  logger("info", "syncFieldValuesWithSubtasks")
-  logger("info", "processing node:", node);
-  logger("info", "processing children:", issues);
-  logger("info", "field mapping: ", fieldMapping);
 
-  issues.map(async (issueItem) => {
-    if (issueItem.closed) {
-      // skip because closed
-      return;
-    }
+  try {
+    const {node} = await kit.graphql(projectV2ItemByNodeId, {project_item_id: roadmapNodeId});
 
-    for (const {from, to} of fieldMapping) {
-      if (from) {
-        const fieldData = node.fieldValues.nodes.find((item: {field?: { id: string }, title: string}) => {
-          return item.field && item.field.id === from
-        });
+    logger("info", "syncFieldValuesWithSubtasks")
+    logger("info", "processing node:", node);
+    logger("info", "processing children:", issues);
+    logger("info", "field mapping: ", fieldMapping);
 
-        const nextValue = fieldData ? fieldData.title : '';
+    issues.map(async (issueItem) => {
+      if (issueItem.closed) {
+        // skip because closed
+        return;
+      }
 
-        if (!isDryRun()) {
-          for (const {projectId, fieldId} of to) {
-            if (fieldId) {
-              await issueItem.setFieldValue(kit, projectId, fieldId, nextValue)
+      for (const {from, to} of fieldMapping) {
+        if (from) {
+          const fieldData = node.fieldValues.nodes.find((item: {field?: { id: string }, title: string}) => {
+            return item.field && item.field.id === from
+          });
+
+          const nextValue = fieldData ? fieldData.title : '';
+
+          if (!isDryRun()) {
+            for (const {projectId, fieldId} of to) {
+              if (fieldId) {
+                try {
+                  await issueItem.setFieldValue(kit, projectId, fieldId, nextValue)
+                } catch(e) {
+                  logger('error', 'Failed to sync fields with subtask')
+                }
+              }
             }
           }
         }
       }
-    }
-  })
+    })
+  } catch(e) {
+    logger("error", 'Failed to fetch issue', e)
+  }
 }
 
 export const handleRoadmapProjectItemChange = async (context: EmitterWebhookEvent<"projects_v2_item.edited"> & Omit<Context<EmitterWebhookEventName>, "id" | "name" | "payload">) => {
@@ -197,7 +101,7 @@ export const handleRoadmapProjectItemChange = async (context: EmitterWebhookEven
       mapping,
     )
   } catch(e) {
-    logger("info", 'Failed to sync fields with subtask ')
+    logger("info", 'Failed to sync fields with subtask catchall', e)
   }
 }
 

--- a/src/shared/issue.ts
+++ b/src/shared/issue.ts
@@ -205,6 +205,11 @@ export class Issue {
       return;
     }
 
+    if (this.closed) {
+      logger("info", "skipping because issue is closed", this.title)
+      return;
+    }
+
     if (!isDryRun()) {
       try {
         const resp = await kit.graphql(setField, {
@@ -237,14 +242,14 @@ export class Issue {
       }
 
       logger("info", `processing ${issueData.repo}#${issueData.number}`);
-      let {data: issue} = await kit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
-        owner: this.owner_login,
-        repo: issueData.repo,
-        issue_number: issueData.number,
-      });
-
-      logger("info", `process ${issue.id}`, issue);
       try {
+        let {data: issue} = await kit.request('GET /repos/{owner}/{repo}/issues/{issue_number}', {
+          owner: this.owner_login,
+          repo: issueData.repo,
+          issue_number: issueData.number,
+        });
+
+        logger("info", `process ${issue.id}`, issue);
         const zIssue = await Issue.load(kit, issue.node_id);
         res.push(zIssue);
         logger("info", `done processing ${issue.title}`);

--- a/src/shared/project_ids.ts
+++ b/src/shared/project_ids.ts
@@ -210,8 +210,6 @@ export const BAAS: ProductDeliveryTeamProject = {
 export const AI_EXPERIMENTS: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak7Jy',
   teamLabelName: 'team/ai',
-  // designStatusFieldId: '...',
-  // figmaLinkFieldId: '...',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak7JyzgdDpRQ'
 }
 
@@ -219,9 +217,6 @@ export const AI_EXPERIMENTS: ProductDeliveryTeamProject = {
 export const QA: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Al5CB',
   teamLabelName: 'team/qa',
-  // designStatusFieldId: '...',
-  // figmaLinkFieldId: '...',
-  // roadmapTargetShipQuarterFieldId: '...'
 }
 
 // project id: 90
@@ -243,4 +238,22 @@ export const PRODUCT_DELIVERY = [
   QA,
   AI_EXPERIMENTS,
   AZURE
+]
+
+export const ALL_TEAMS_PROJECTS = [
+  ...PRODUCT_DELIVERY,
+  CONSOLE,
+  ENGINEERING,
+  PRODUCT_DESIGN,
+  INFRA,
+  AUTOSCALING,
+  CONTROL_PLANE,
+  DATA,
+  COMPUTE,
+  DOCS,
+  POSTGRES,
+  PRODUCT,
+  PIXEL_POINT,
+  ALL_EPICS,
+  NEON_RELEASE_STATUS,
 ]

--- a/src/shared/project_ids.ts
+++ b/src/shared/project_ids.ts
@@ -1,5 +1,19 @@
+interface NeonProject {
+  projectId: string;
+  trackedInFieldId?: string;
+  forceSyncFieldId?: string;
+  targetShipMothFieldId?: string;
+  targetShipQuarterFieldId?: string;
+  progressFieldId?: string;
+  roadmapTargetShipMonthFieldId?: string;
+  roadmapTargetShipQuarterFieldId?: string;
+  statusFieldId?: string;
+  figmaLinkFieldId?: string;
+  statusLastUpdatedFieldId?: string;
+}
+
 // project id: 8
-export const NEON_PRIVATE_ROADMAP = {
+export const NEON_PRIVATE_ROADMAP: NeonProject = {
   projectId: "PVT_kwDOBKF3Cs4ADWZl",
   targetShipMothFieldId: "PVTIF_lADOBKF3Cs4ADWZlzgB7V1c",
   targetShipQuarterFieldId: "PVTIF_lADOBKF3Cs4ADWZlzgJK-lA",
@@ -7,7 +21,7 @@ export const NEON_PRIVATE_ROADMAP = {
 };
 
 // project id: 21
-export const CONSOLE = {
+export const CONSOLE: NeonProject = {
   projectId: "PVT_kwDOBKF3Cs4AMKWT",
   trackedInFieldId: 'PVTF_lADOBKF3Cs4AMKWTzgHwfhM',
   progressFieldId: 'PVTF_lADOBKF3Cs4AMKWTzgHwfhU',
@@ -16,7 +30,7 @@ export const CONSOLE = {
 };
 
 // project id: 6
-export const ENGINEERING = {
+export const ENGINEERING: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs1e-g',
   trackedInFieldId: 'PVTF_lADOBKF3Cs1e-s4AB3Qt',
   progressFieldId: 'PVTF_lADOBKF3Cs1e-s4ADvDB',
@@ -24,18 +38,23 @@ export const ENGINEERING = {
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs1e-s4Ck_-L',
 };
 
+interface DesignProject extends NeonProject {
+  statusFieldId: string, figmaLinkFieldId: string
+}
+
 // project id: 17
-export const PRODUCT_DESIGN = {
+export const PRODUCT_DESIGN: DesignProject = {
   projectId: 'PVT_kwDOBKF3Cs4AL_Xj',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AL_XjzgKe_xI',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4AL_XjzgL3Peo',
   trackedInFieldId: 'PVTF_lADOBKF3Cs4AL_XjzgL3Qvg',
   statusFieldId: 'PVTSSF_lADOBKF3Cs4AL_XjzgHpb8U',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4AL_XjzgIGS9w',
   forceSyncFieldId: 'PVTF_lADOBKF3Cs4AL_XjzgfGov4',
 };
 
 // project id: 37
-export const INFRA = {
+export const INFRA: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4AQhn_',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AQhn_zgKjQLU',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4AQhn_zgKjQLQ',
@@ -43,7 +62,7 @@ export const INFRA = {
 }
 
 // project id: 50
-export const AUTOSCALING = {
+export const AUTOSCALING: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4ASNuf',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4ASNufzgLodD0',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4ASNufzgLodDw',
@@ -52,7 +71,7 @@ export const AUTOSCALING = {
 }
 
 // project id: 48
-export const CONTROL_PLANE = {
+export const CONTROL_PLANE: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4ASIxL',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4ASIxLzgLlRoA',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4ASIxLzgLlRn8',
@@ -60,7 +79,7 @@ export const CONTROL_PLANE = {
 }
 
 // project id: 14
-export const DATA = {
+export const DATA: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4ALGJW',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4ALGJWzgL3Pu8',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4ALGJWzgL3PuQ',
@@ -68,7 +87,7 @@ export const DATA = {
 }
 
 // project id: 49
-export const COMPUTE = {
+export const COMPUTE: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4ASNk7',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4ASNk7zgLoW6k',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4ASNk7zgLoW6g',
@@ -76,7 +95,7 @@ export const COMPUTE = {
 }
 
 // project id: 25
-export const DOCS = {
+export const DOCS: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4ANGVj',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4ANGVjzgL3PwQ',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4ANGVjzgL3Pw8',
@@ -84,7 +103,7 @@ export const DOCS = {
 }
 
 // project id: 32
-export const POSTGRES = {
+export const POSTGRES: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4AQQPR',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AQQPRzgL3QBI',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4AQQPRzgL3QAc',
@@ -92,7 +111,7 @@ export const POSTGRES = {
 }
 
 // project id: 11
-export const PRODUCT = {
+export const PRODUCT: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4AHA73',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AHA73zgL3Pzo',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4AHA73zgL3Pzk',
@@ -100,7 +119,7 @@ export const PRODUCT = {
 }
 
 // project id: 10
-export const PIXEL_POINT = {
+export const PIXEL_POINT: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4AFa_n',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AFa_nzgL3Q_s',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4AFa_nzgL3Q_A',
@@ -108,14 +127,14 @@ export const PIXEL_POINT = {
 }
 
 // project id: 64
-export const ALL_EPICS = {
+export const ALL_EPICS: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4AUkqb',
   roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AUkqbzgNJOys',
   roadmapTargetShipMonthFieldId: 'PVTF_lADOBKF3Cs4AUkqbzgNJOyo',
 }
 
 // project id: 79
-export const NEON_RELEASE_STATUS = {
+export const NEON_RELEASE_STATUS: NeonProject = {
   projectId: 'PVT_kwDOBKF3Cs4AfDv2',
   statusLastUpdatedFieldId: 'PVTF_lADOBKF3Cs4AfDv2zgZ0RRw',
   statusFieldId: 'PVTSSF_lADOBKF3Cs4AfDv2zgUgpnk',
@@ -123,63 +142,105 @@ export const NEON_RELEASE_STATUS = {
 
 
 // Product delivery projects
+interface ProductDeliveryTeamProject extends NeonProject {
+  teamLabelName: string;
+  designStatusFieldId?: string;
+  figmaLinkFieldId?: string;
+  roadmapTargetShipQuarterFieldId?: string;
+}
 
 // project id: 95
-export const IDENTITY = {
+export const IDENTITY: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak_eq',
   trackedInFieldId: 'PVTF_lADOBKF3Cs4Ak_eqzgdHTgc',
-  teamLabelName: 'team/identity 🆔'
+  teamLabelName: 'team/identity 🆔',
+  designStatusFieldId: 'PVTF_lADOBKF3Cs4Ak_eqzgfNd0g',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4Ak_eqzgfNd10',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak_eqzgfNlkU'
 }
 
 // project id: 87
-export const DBAAS = {
+export const DBAAS: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4AkjdS',
   trackedInFieldId: 'PVTF_lADOBKF3Cs4AkjdSzgcvnTs',
   teamLabelName: 'team/dbaas',
   designStatusFieldId: 'PVTF_lADOBKF3Cs4AkjdSzgfGXDk',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4AkjdSzgfNck4',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AkjdSzgfNlKw'
 }
 
 // project id: 89
-export const WORKFLOW = {
+export const WORKFLOW: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak7Jm',
   trackedInFieldId: 'PVTF_lADOBKF3Cs4Ak7JmzgdDpF0',
   teamLabelName: 'team/workflow',
+  designStatusFieldId: 'PVTF_lADOBKF3Cs4Ak7JmzgfNqC0',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4Ak7JmzgfNqC4',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak7JmzgdDpGM'
 }
 
 // project id: 93
-export const BILLING = {
+export const BILLING: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak7J2',
-  teamLabelName: 'team/billing 💰'
+  teamLabelName: 'team/billing 💰',
+  designStatusFieldId: 'PVTF_lADOBKF3Cs4Ak7J2zgfOUZo',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4Ak7J2zgfOUb8',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak7J2zgfOUfw'
 }
 
 // project id: 85
-export const GROWTH = {
+export const GROWTH: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4AkUgD',
-  teamLabelName: 'team/growth'
+  teamLabelName: 'team/growth',
+  designStatusFieldId: 'PVTF_lADOBKF3Cs4AkUgDzgfOUuY',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4AkUgDzgfOUww',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4AkUgDzgci9uA'
 }
 
 // project id: 88
-export const BAAS = {
+export const BAAS: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak7JT',
-  teamLabelName: 'team/baas'
+  teamLabelName: 'team/baas',
+  designStatusFieldId: 'PVTF_lADOBKF3Cs4Ak7JTzgfOU50',
+  figmaLinkFieldId: 'PVTF_lADOBKF3Cs4Ak7JTzgfOU7Y',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak7JTzgdDo18'
 }
 
 // project id: 91
-export const AI_EXPERIMENTS = {
+export const AI_EXPERIMENTS: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak7Jy',
-  teamLabelName: 'team/ai'
+  teamLabelName: 'team/ai',
+  // designStatusFieldId: '...',
+  // figmaLinkFieldId: '...',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak7JyzgdDpRQ'
 }
 
 // project id: 98
-export const QA = {
+export const QA: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Al5CB',
-  teamLabelName: 'team/qa'
+  teamLabelName: 'team/qa',
+  // designStatusFieldId: '...',
+  // figmaLinkFieldId: '...',
+  // roadmapTargetShipQuarterFieldId: '...'
 }
 
 // project id: 90
-export const AZURE = {
+export const AZURE: ProductDeliveryTeamProject = {
   projectId: 'PVT_kwDOBKF3Cs4Ak7Jt',
-  teamLabelName: 'team/azure'
+  teamLabelName: 'team/azure',
+  // designStatusFieldId: '...',
+  // figmaLinkFieldId: '...',
+  roadmapTargetShipQuarterFieldId: 'PVTF_lADOBKF3Cs4Ak7JtzgdDpNA'
 }
 
-
+export const PRODUCT_DELIVERY = [
+  BILLING,
+  IDENTITY,
+  DBAAS,
+  BAAS,
+  WORKFLOW,
+  GROWTH,
+  QA,
+  AI_EXPERIMENTS,
+  AZURE
+]


### PR DESCRIPTION
This PR containes a bunch of changes:
* fix for a bug when syncing roadmap desired ship quarter automation was breaking while trying to load children issues
* enables syncing Status and Figma Link fields from Product design project to Identity, DBaaS, Workflow, Billing, Growth, BaaS projects
* enables syncing Roadmap Desired Ship Quarter to [Product delivery projects](https://github.com/orgs/neondatabase/projects?query=is%3Aopen+PD)